### PR TITLE
support for gatsby-plugin-sharp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 site/node_modules
 site/public
 site/.cache
+
+# This is ignored in this Docker image project as we don't really wan't to build
+# sites here locally, instead site folder used for testing gatsby workflows.
+/site

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,17 @@ FROM node:9.5-alpine
 
 EXPOSE 8000
 
-RUN apk update && apk add git
-RUN npm install -g gatsby@1.9
+RUN apk update && \
+    apk add --update --repository http://dl-3.alpinelinux.org/alpine/edge/testing vips-tools vips-dev fftw-dev gcc g++ make libc6-compat && \
+    apk add git && \
+    apk add python && \
+    python -m ensurepip && \
+    rm -r /usr/lib/python*/ensurepip && \
+    pip install --upgrade pip setuptools && \
+    rm -r /root/.cache && \
+    rm -rf /var/cache/apk/*
+
+RUN npm install --global gatsby --no-optional gatsby@1.9 
 
 RUN mkdir -p /site
 WORKDIR /site

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,6 @@ RUN apk update && \
     apk add --update --repository http://dl-3.alpinelinux.org/alpine/edge/testing vips-tools vips-dev fftw-dev gcc g++ make libc6-compat && \
     apk add git && \
     apk add python && \
-    python -m ensurepip && \
-    rm -r /usr/lib/python*/ensurepip && \
-    pip install --upgrade pip setuptools && \
-    rm -r /root/.cache && \
     rm -rf /var/cache/apk/*
 
 RUN npm install --global gatsby --no-optional gatsby@1.9 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Develop &amp; Build [GatsbyJS](https://www.gatsbyjs.org/) static sites within a 
 - 🚮  **Clutter-free host machine**: No need to install Node/Gatsby/Webpack/etc on your host machine! Only Docker required (tested on `v17.12.0`).
 - 🏗  **Easy setup**: Automatic GatsbyJS site initializion with [`gatsby-starter-default`](http://gatsbyjs.github.io/gatsby-starter-default/) (unless already initialized)
 - 👍  **Simple CLI API**: [`develop`/`stage`/`build`](#usage)
-- 🍃  **Lightweight**'ish Docker image (size only ~`250 MB`)
 - 🆕  **Recent NodeJS**: Container based on [NodeJS `v9.5` running in Alpine Linux](https://github.com/nodejs/docker-node/blob/db3b27c8388136b5e529861d7c3fa12fd8328301/9/alpine/Dockerfile)
 - 📃  [MIT](https://github.com/aripalo/gatsby-docker/blob/master/LICENSE)-licensed
 


### PR DESCRIPTION
Sharp requires quite a bit stuff. Some of these might be redundant, but further testing is needed.

Will merge after testing (and hopefully getting rid off some dependencies & making the container size smaller).

---

To test:

1. Clone this repo and change to this branch:

    ```sh
    git clone git@github.com:aripalo/gatsby-docker.git
    cd gatsby-docker
    git checkout sharp-support
    ```

2. Build the image and make sure it runs:

    ```sh
    docker build -t gatsby-docker-with-sharp . --no-cache
    docker run -it --rm -v $(pwd)/site:/site gatsby-docker-with-sharp:latest build 
    ```
3. Install `gatsby-plugin-sharp` and test:

    ```sh
    docker run -it --rm -v $(pwd)/site:/site gatsby-docker-with-sharp:latest yarn add gatsby-plugin-sharp
    docker run -it --rm -v $(pwd)/site:/site -p 8000:8000 gatsby-docker-with-sharp:latest develop
    ```